### PR TITLE
Enable to overwrite colors

### DIFF
--- a/lua/rainbow/internal.lua
+++ b/lua/rainbow/internal.lua
@@ -47,7 +47,7 @@ function M.attach(bufnr, lang)
   end
 
   for i = 1, #colors do -- define highlight groups
-    local s = "highlight rainbowcol" .. i .. " guifg=" .. colors[i]
+    local s = "highlight default rainbowcol" .. i .. " guifg=" .. colors[i]
     vim.cmd(s)
   end
 


### PR DESCRIPTION
With this patch, we can overwrite the colors from `init.vim` / `init.lua`.

```vim
" in init.vim
hi link rainbowcol1 #123456
hi link rainbowcol2 #123456
...
```