### PR TITLE
WIP: incremental updates

### DIFF
--- a/lua/rainbow/internal.lua
+++ b/lua/rainbow/internal.lua
@@ -34,54 +34,44 @@ local function color_no(mynode, len)
         end
 end
 
-local callbackfn = function(bufnr, parser)
-        -- no need to do anything when pum is open
-        if vim.fn.pumvisible() == 1 then
-                return
-        end
+local callbackfn = function(bufnr, _, changes, tree, lang)
+        --vim.schedule_wrap(function()
+                -- no need to do anything when pum is open
+                if vim.fn.pumvisible() == 1 or not lang then
+                        return
+                end
 
-        --clear highlights or code commented out later has highlights too
-        vim.api.nvim_buf_clear_namespace(bufnr, nsid, 0, -1)
-        parser:parse()
-        parser:for_each_tree(function(tree, lang_tree)
-                local root_node = tree:root()
+                for _, change in ipairs(changes) do
 
-                local lang = lang_tree:lang()
-                local query = queries.get_query(lang, "parens")
-                if query ~= nil then
-                        for _, node, _ in query:iter_captures(root_node, bufnr) do
-                                -- set colour for this nesting level
-                                local color_no_ = color_no(node, #colors)
-                                local _, startCol, endRow, endCol = node:range() -- range of the capture, zero-indexed
-                                vim.highlight.range(
-                                        bufnr,
-                                        nsid,
-                                        ("rainbowcol" .. color_no_),
-                                        { endRow, startCol },
-                                        { endRow, endCol - 1 },
-                                        "blockwise",
-                                        true
-                                )
+                        ----clear highlights or code commented out later has highlights too
+                        vim.api.nvim_buf_clear_namespace(bufnr, nsid, change[1], change[3])
+                        local root_node =  tree:root()
+                        local query = queries.get_query(lang, "parens")
+                        if query ~= nil then
+                                for _, node, _ in query:iter_captures(root_node, bufnr, change[1], change[3] + 1) do
+                                        -- set colour for this nesting level
+                                        local color_no_ = color_no(node, #colors)
+                                        local _, startCol, endRow, endCol = node:range() -- range of the capture, zero-indexed
+                                        vim.highlight.range(
+                                                bufnr,
+                                                nsid,
+                                                ("rainbowcol" .. color_no_),
+                                                { endRow, startCol },
+                                                { endRow, endCol - 1 },
+                                                "blockwise",
+                                                true
+                                        )
+                                end
                         end
                 end
-        end)
+        --end)()
 end
 
-local function try_async(f, bufnr, parser)
-        local cancel = false
-        return function()
-                if cancel then
-                        return true
-                end
-                local async_handle
-                async_handle = vim.loop.new_async(vim.schedule_wrap(function()
-                        f(bufnr, parser)
-                        async_handle:close()
-                end))
-                async_handle:send()
-        end, function()
-                cancel = true
-        end
+local function full_update(bufnr)
+        local parser = parsers.get_parser(bufnr)
+        parser:for_each_tree(function(tree, sub_parser)
+                callbackfn(bufnr, sub_parser, {{tree:root():range()}}, tree, sub_parser:lang())
+        end)
 end
 
 local function register_predicates(config)
@@ -105,10 +95,13 @@ function M.attach(bufnr, lang)
         local config = configs.get_module("rainbow")
         register_predicates(config)
 
-        local attachf, detachf = try_async(callbackfn, bufnr, parser)
-        state_table[bufnr] = detachf
-        callbackfn(bufnr, parser) -- do it on attach
-        vim.api.nvim_buf_attach(bufnr, false, { on_lines = attachf }) --do it on every change
+        --local attachf, detachf = try_async(callbackfn, bufnr, parser)
+        --state_table[bufnr] = detachf
+        --callbackfn(bufnr, parser) -- do it on attach
+
+        full_update(bufnr)
+        parser:register_cbs({on_changedtree = function(...) callbackfn(bufnr, parser, ...) end})
+        --vim.api.nvim_buf_attach(bufnr, false, { on_lines = attachf }) --do it on every change
 end
 
 function M.detach(bufnr)


### PR DESCRIPTION
- don't know whether this is faster
- clearing the namespace is wrong, since multiple languages can be in the same line. Probably, we need a namespace per parser.
- I applied this change in `languagetree.lua` in Neovim repo (add `self._lang` to callback). A better solution would be to get the `lang` from the parser.
```lua
function LanguageTree:parse()
  if self._valid then
    return self._trees
  end

  local parser = self._parser
  local changes = {}

  local old_trees = self._trees
  self._trees = {}

  -- If there are no ranges, set to an empty list
  -- so the included ranges in the parser are cleared.
  if self._regions and #self._regions > 0 then
    for i, ranges in ipairs(self._regions) do
      local old_tree = old_trees[i]
      parser:set_included_ranges(ranges)

      local tree, tree_changes = parser:parse(old_tree, self._source)
      self:_do_callback('changedtree', tree_changes, tree, self._lang)

      table.insert(self._trees, tree)
      vim.list_extend(changes, tree_changes)
    end
  else
    local tree, tree_changes = parser:parse(old_trees[1], self._source)
    self:_do_callback('changedtree', tree_changes, tree, self._lang)

```

Addresses #5