### PR TITLE
Add `max_file_lines` option back

### DIFF
--- a/lua/rainbow/internal.lua
+++ b/lua/rainbow/internal.lua
@@ -129,6 +129,10 @@ M.defhl()
 function M.attach(bufnr, lang)
     local parser = parsers.get_parser(bufnr, lang)
     local config = configs.get_module("rainbow")
+    local max_file_lines = config.max_file_lines
+    if max_file_lines ~= nil and vim.api.nvim_buf_line_count(bufnr) > max_file_lines then
+        return
+    end
     register_predicates(config)
     full_update(bufnr)
     state_table[bufnr] = true


### PR DESCRIPTION
Not sure if this was removed on accident or on purpose, but it is still referenced in the README.