### PR TITLE
Fix elixir queries according to the new official grammar

### DIFF
--- a/queries/elixir/parens.scm
+++ b/queries/elixir/parens.scm
@@ -1,11 +1,8 @@
 ; inherits: square,round,curly
-(binary
+(bitstring
   "<<" @left
   ">>" @right)
 (map
-  "%{" @left
-  "}" @right)
-(struct
   "%" @left
   "{" @left
   "}" @right)
@@ -13,5 +10,5 @@
   "#{" @left
   "}" @right)
 (sigil
-  (sigil_start) @left
-  (sigil_end) @right)
+  (sigil_name) @left
+  (sigil_modifiers) @right)


### PR DESCRIPTION
Some objects had their names changed or ceased to exist with the new [grammar](https://github.com/elixir-lang/tree-sitter-elixir), which led to errors on tree-sitter. I've updated them accordingly in the elixir queries.