### PR TITLE
Add support for python

### DIFF
--- a/lua/rainbow/internal.lua
+++ b/lua/rainbow/internal.lua
@@ -23,17 +23,22 @@ local termcolors = get_colors(configs, "termcolors")
 local function color_no(mynode, len, levels)
     local counter = 0
     local current = mynode
+    local found = false
     while current:parent() ~= nil do
         if levels then
             if levels[current:type()] then
                 counter = counter + 1
+                found = true
             end
         else
             counter = counter + 1
+            found = true
         end
         current = current:parent()
     end
-    if counter % len == 0 then
+    if not found then
+        return 1
+    elseif counter % len == 0 then
         return len
     else
         return (counter % len)

--- a/lua/rainbow/levels.lua
+++ b/lua/rainbow/levels.lua
@@ -1,4 +1,18 @@
 return {
+    python = {
+        tuple = true,
+        list = true,
+        dictionary = true,
+        set = true,
+        subscript = true,
+        argument_list = true,
+        parameters = true,
+        parenthesized_expression = true,
+        generator_expression = true,
+        list_comprehension = true,
+        dictionary_comprehension = true,
+        set_comprehension = true,
+    },
     rust = {
         arguments = true,
         array_expression = true,


### PR DESCRIPTION
Set the treesitter objects that use some form of brackets in Python
Have the color level function in internal.lua return 1 if no levels are found