### PR TITLE
run get_parser after max_file_lines check

### DIFF
--- a/lua/rainbow/internal.lua
+++ b/lua/rainbow/internal.lua
@@ -132,7 +132,6 @@ end
 M.defhl()
 
 function M.attach(bufnr, lang)
-    local parser = parsers.get_parser(bufnr, lang)
     local config = configs.get_module("rainbow")
     local max_file_lines = config.max_file_lines
     if max_file_lines ~= nil and vim.api.nvim_buf_line_count(bufnr) > max_file_lines then
@@ -141,6 +140,7 @@ function M.attach(bufnr, lang)
     register_predicates(config)
     full_update(bufnr)
     state_table[bufnr] = true
+    local parser = parsers.get_parser(bufnr, lang)
     parser:register_cbs({
         on_changedtree = function(changes, tree)
             if state_table[bufnr] == true then


### PR DESCRIPTION
I noticed that for large files, having the get_parser call in the
beginning already slows down loading a bit.
Since the variable isn't necessary there, we can just move it further
down.