### PR TITLE
Highlight c compound_statement

### DIFF
--- a/lua/rainbow/levels.lua
+++ b/lua/rainbow/levels.lua
@@ -47,6 +47,7 @@ return {
     c = {
         array_declarator = true,
         call_expression = true,
+        compound_statement = true,
         enumerator_list = true,
         field_declaration_list = true,
         for_statement = true,


### PR DESCRIPTION
Makes it so that braces indicating scoping in c also get highlighted.

before:
![image](https://user-images.githubusercontent.com/57052305/149059593-5fa3b490-0473-4bf0-b9e3-3fced3d1274e.png)

after:
![image](https://user-images.githubusercontent.com/57052305/149059652-4b7d53cc-8923-42f7-a355-5942aced113f.png)
