### PR TITLE
fix(update_range): api changes on nightly #17462

### DIFF
--- a/lua/rainbow/internal.lua
+++ b/lua/rainbow/internal.lua
@@ -65,9 +65,11 @@ local function update_range(bufnr, changes, tree, lang)
                         ("rainbowcol" .. color_no_),
                         { startRow, startCol },
                         { endRow, endCol - 1 },
-                        "blockwise",
-                        true,
-                        120
+                        {
+                            regtype = "blockwise",
+                            inclusive = true,
+                            priority = 120,
+                        }
                     )
                 end
             end


### PR DESCRIPTION
* see https://github.com/neovim/neovim/pull/17462

Highlighting is currently broken due to the way update_range is called in internal.lua.
It should be noted that this fix is only intended for people using neovim-nightly.

As the README doesn't say anything about the targeted neovim version and nvim-treesitter is recommending using nightly anyway this might be fine.