### PR TITLE
rescript: remove angle

### DIFF
--- a/queries/rescript/parens.scm
+++ b/queries/rescript/parens.scm
@@ -1,1 +1,9 @@
-; inherits: square,round,curly,angle
+; inherits: square,round,curly
+
+(type_parameters
+ "<" @paren
+ ">" @paren)
+
+(type_arguments
+ "<" @paren
+ ">" @paren)


### PR DESCRIPTION
The `angle` was removed because the colors in jsx were not matching