### PR TITLE
Add TSX highlight tests

### DIFF
--- a/queries/jsx/parens.scm
+++ b/queries/jsx/parens.scm
@@ -1,21 +1,24 @@
 ; inherits: square,round,curly
 
 ((jsx_opening_element
-   ["<" ">"] @left-delimiters
+   "<" @left-tag-start
    name: _ @left
- ) (#jsx-extended-rainbow-mode?))
+   ">" @left-tag-end
+ ) (#jsx-extended-rainbow-mode? @left-tag-start @left-tag-end @left))
 
 ((jsx_self_closing_element
-   ; Combining "/" with "<" results in "invalid node type" treesitter error
-   ["<" "/" ">"] @self-closing-delimiters
-   name: _ @self-closing
- ) (#jsx-extended-rainbow-mode?))
+   "<"+ @self-closing-tag-start
+   name: _ @self-closing (#jsx-extended-rainbow-mode?)
+   ; Combining "/" with "<" results in no JSX highlights
+   ["/" ">"]+ @self-closing-tag-end
+ ) (#jsx-extended-rainbow-mode? @self-closing-tag-start @self-closing-tag-end @self-closing))
 
 ((jsx_closing_element
-   ; Combining "/" with ">" results in "invalid node type" treesitter error
-   ["<" "/" ">"] @right-delimiters
+   ; Combining "/" with "<" results in no JSX highlights
+   ["<" "/"]+ @right-tag-start
    name: _ @right
- ) (#jsx-extended-rainbow-mode?))
+   ">" @right-tag-end
+ ) (#jsx-extended-rainbow-mode? @right-tag-start @right-tag-end @right))
 
 ; [(jsx_element
 ;    open_tag: (jsx_opening_element) @left

--- a/test/highlight/highlight_spec.lua
+++ b/test/highlight/highlight_spec.lua
@@ -146,114 +146,119 @@ local function remove_duplicate_highlighted_symbols(highlighted_symbols, source_
     assert(not multiple_highlights_for_symbols, "There are multiple highlights for some symbols")
 end
 
-describe("TSX highlighting", function()
-    it("should highlight", function()
-        -- TODO: enable based on file name
-        require("nvim-treesitter.configs").get_module("rainbow").extended_mode = true
-        vim.cmd.edit("test.tsx")
-        assert.equals("typescriptreact", vim.bo.filetype, "Invalid filetype")
+local function verify_highlights_in_file(filename)
+    local extended_mode = string.find(filename, "extended") ~= nil
+    local rainbow_module = require("nvim-treesitter.configs").get_module("rainbow")
+    rainbow_module.extended_mode = extended_mode
 
-        -- TODO: read source code from files
-        -- https://github.com/nvim-treesitter/nvim-treesitter/blob/a9a6493b1eeba458757903352e0d3dc4b54fd4f2/tests/query/highlights_spec.lua#L100
-        local source_code = [[
-    const abc = {};
-//hl            11
-    function MyComponent() {
-//hl                    11 1
-      return <div>Hello world</div>;
-//hl         22222           222222
-    }
-//hl1
-        ]]
-        local source_code_lines = vim.fn.split(source_code, "\n")
+    vim.cmd.edit(filename)
 
-        vim.api.nvim_buf_set_lines(0, 0, -1, true, source_code_lines)
+    local source_code_lines = vim.api.nvim_buf_get_lines(0, 0, -1, 1)
 
-        local rainbow_ns_id = vim.api.nvim_get_namespaces().rainbow_ns
-        assert.not_equal(nil, rainbow_ns_id, "rainbow namespace not found")
+    vim.api.nvim_buf_set_lines(0, 0, -1, true, source_code_lines)
 
-        local parser = require("nvim-treesitter.parsers").get_parser(0)
-        assert.truthy(parser, "Parser not found")
-        parser:parse()
+    local rainbow_ns_id = vim.api.nvim_get_namespaces().rainbow_ns
+    assert.not_equal(nil, rainbow_ns_id, "rainbow namespace not found")
 
-        -- NOTE: nvim_buf_get_extmarks does not return extmarks that contain
-        -- some range. It only returns extmarks within the given range.
-        -- We cannot use it to look for extmarks for a given symbol, because sometimes
-        -- the extmarks are for a range (e.g. when highlighting a JSX tag, the
-        -- whole range "div" is a single extmark and asking for an extmark for
-        -- the position of "i" returns nothing).
-        -- Thus, we must filter through all extmarks set on the buffer and
-        -- check each symbol.
-        local extmarks = vim.api.nvim_buf_get_extmarks(0, rainbow_ns_id, 0, -1, { details = true })
-        local highlighted_symbols = get_highlighted_symbols_from_extmarks(extmarks)
+    local parser = require("nvim-treesitter.parsers").get_parser(0)
+    assert.truthy(parser, "Parser not found")
+    parser:parse()
 
-        remove_duplicate_highlighted_symbols(highlighted_symbols, source_code_lines)
+    -- NOTE: nvim_buf_get_extmarks does not return extmarks that contain
+    -- some range. It only returns extmarks within the given range.
+    -- We cannot use it to look for extmarks for a given symbol, because sometimes
+    -- the extmarks are for a range (e.g. when highlighting a JSX tag, the
+    -- whole range "div" is a single extmark and asking for an extmark for
+    -- the position of "i" returns nothing).
+    -- Thus, we must filter through all extmarks set on the buffer and
+    -- check each symbol.
+    local extmarks = vim.api.nvim_buf_get_extmarks(0, rainbow_ns_id, 0, -1, { details = true })
+    local highlighted_symbols = get_highlighted_symbols_from_extmarks(extmarks)
 
-        for _, expected_highlight in ipairs(get_expected_highlights(source_code_lines)) do
-            local symbol_highlighted = false
+    remove_duplicate_highlighted_symbols(highlighted_symbols, source_code_lines)
 
-            -- NOTE: loop from the end to allow removing elements inside of the loop
-            -- without changing the indices that will be looped over
-            for i = #highlighted_symbols, 1, -1 do
-                local highlighted_symbol = highlighted_symbols[i]
-                if
-                    highlighted_symbol.line == expected_highlight.line
-                    and highlighted_symbol.column == expected_highlight.column
-                then
-                    symbol_highlighted = true
+    local some_symbol_not_highlighted = false
+    local invalid_highlight = false
+    for _, expected_highlight in ipairs(get_expected_highlights(source_code_lines)) do
+        local symbol_highlighted = false
 
-                    local expected_highlight_group =
-                        get_rainbow_highlight_group_name(expected_highlight.rainbow_level)
-                    if expected_highlight_group ~= highlighted_symbol.hl_group then
-                        print(
-                            string.format(
-                                'Invalid rainbow highlight group. Expected "%s", found "%s"',
-                                expected_highlight_group,
-                                highlighted_symbol.hl_group
-                            )
+        -- NOTE: loop from the end to allow removing elements inside of the loop
+        -- without changing the indices that will be looped over
+        for i = #highlighted_symbols, 1, -1 do
+            local highlighted_symbol = highlighted_symbols[i]
+            if
+                highlighted_symbol.line == expected_highlight.line
+                and highlighted_symbol.column == expected_highlight.column
+            then
+                symbol_highlighted = true
+
+                local expected_highlight_group =
+                    get_rainbow_highlight_group_name(expected_highlight.rainbow_level)
+                if expected_highlight_group ~= highlighted_symbol.hl_group then
+                    invalid_highlight = true
+                    print(
+                        string.format(
+                            'Invalid rainbow highlight group. Expected "%s", found "%s"',
+                            expected_highlight_group,
+                            highlighted_symbol.hl_group
                         )
-                        print_line_with_error_marker(
-                            source_code_lines[expected_highlight.line + 1],
-                            expected_highlight.line + 1,
-                            expected_highlight.column
-                        )
-                    end
-
-                    -- NOTE: remove the matched highlighted symbol to later
-                    -- check that all highlighted symbols matched some expected
-                    -- highlight
-                    table.remove(highlighted_symbols, i)
-                end
-            end
-
-            if not symbol_highlighted then
-                print(
-                    string.format(
-                        'No highlight groups detected. Expected "%s".',
-                        get_rainbow_highlight_group_name(expected_highlight.rainbow_level)
                     )
-                )
-                print_line_with_error_marker(
-                    source_code_lines[expected_highlight.line + 1],
-                    expected_highlight.line + 1,
-                    expected_highlight.column
-                )
+                    print_line_with_error_marker(
+                        source_code_lines[expected_highlight.line + 1],
+                        expected_highlight.line + 1,
+                        expected_highlight.column
+                    )
+                end
+
+                -- NOTE: remove the matched highlighted symbol to later
+                -- check that all highlighted symbols matched some expected
+                -- highlight
+                table.remove(highlighted_symbols, i)
             end
         end
 
-        for _, symbol in ipairs(highlighted_symbols) do
+        if not symbol_highlighted then
             print(
                 string.format(
-                    'Symbol was extraneously highlighted with highlight group "%s"',
-                    symbol.hl_group
+                    'No highlight groups detected. Expected "%s".',
+                    get_rainbow_highlight_group_name(expected_highlight.rainbow_level)
                 )
             )
             print_line_with_error_marker(
-                source_code_lines[symbol.line + 1],
-                symbol.line + 1,
-                symbol.column
+                source_code_lines[expected_highlight.line + 1],
+                expected_highlight.line + 1,
+                expected_highlight.column
             )
+            some_symbol_not_highlighted = true
         end
-        assert(#highlighted_symbols == 0, "Extraneous highlights")
-    end)
+    end
+
+    for _, symbol in ipairs(highlighted_symbols) do
+        print(
+            string.format(
+                'Symbol was extraneously highlighted with highlight group "%s"',
+                symbol.hl_group
+            )
+        )
+        print_line_with_error_marker(
+            source_code_lines[symbol.line + 1],
+            symbol.line + 1,
+            symbol.column
+        )
+    end
+    assert(not invalid_highlight, "Some symbol was incorrectly highlighted")
+    assert(not some_symbol_not_highlighted, "Some symbol was not highlighted")
+    assert(#highlighted_symbols == 0, "Extraneous highlights")
+end
+
+describe("Highlighting integration tests", function()
+    local files = vim.fn.glob("test/highlight/**/*.*", nil, true)
+
+    for _, filename in ipairs(files) do
+        if not string.match(filename, "highlight_spec.lua") then
+            it(filename, function()
+                verify_highlights_in_file(filename)
+            end)
+        end
+    end
 end)

--- a/test/highlight/tsx/extended.tsx
+++ b/test/highlight/tsx/extended.tsx
@@ -1,0 +1,24 @@
+const abc = {};
+// hl       11
+
+// NOTE: there are syntax errors because of using // as comments in JSX.
+// Using {/* */} as comments would lead to the braces being highlighted
+// which would require more and more comments
+
+// prettier-ignore
+function MyComponent() {
+    // hl           11 1
+    return (
+    // hl  2
+        <div>
+// hl   33333
+            <span>Hello world</span>
+    // hl   444444           4444444
+            <img src="self closing" />
+    // hl   4444                    44
+        </div>
+//hl    333333
+     );
+// hl2
+     }
+// hl1

--- a/test/highlight/tsx/regular.tsx
+++ b/test/highlight/tsx/regular.tsx
@@ -1,0 +1,15 @@
+const abc = {};
+// hl       11
+// prettier-ignore
+function MyComponent() {
+    // hl           11 1
+    return (
+    // hl  2
+        <div>
+            <span>Hello world</span>
+            <img src="self closing" />
+        </div>
+     );
+// hl2
+     }
+// hl1

--- a/test/highlight/tsx_spec.lua
+++ b/test/highlight/tsx_spec.lua
@@ -1,0 +1,148 @@
+---@class ExpectedRainbowHighlight
+---@field line number 0-based index of the line to be highlighted
+---@field column number 0-based index of the character to be highlighted
+---@field rainbow_level string The expected level of the rainbow to use in the highlight
+
+---@param source_code_lines string[]
+---@return ExpectedRainbowHighlight[]
+local function get_expected_highlights(source_code_lines)
+    ---@type ExpectedRainbowHighlight[]
+    local expected_highlights = {}
+
+    for line_index, line in ipairs(source_code_lines) do
+        local matches = string.find(line, "hl[%s%d]*")
+        if matches ~= nil then
+            for char_index = 1, #line do
+                local char = line:sub(char_index, char_index)
+                if string.match(char, "%d") then
+                    table.insert(expected_highlights, {
+                        -- NOTE: subtract 1 to get the index to be 0-based,
+                        -- and another 1 because the hl-line describes the
+                        -- expected highlights for the line above the hl-line
+                        line = line_index - 2,
+                        column = char_index - 1,
+                        rainbow_level = char,
+                    })
+                end
+            end
+        end
+    end
+
+    return expected_highlights
+end
+
+---Returns the name of the rainbow highlight group for a given level
+---@param level string
+---@return string
+local function get_rainbow_highlight_group_name(level)
+    return "rainbowcol" .. level
+end
+
+---Prepares a line with the invalid column marked by ^.
+---Used in error reporting.
+---@param invalid_column number 0-based
+---@return string
+local function get_error_marker_line(invalid_column)
+    return string.rep(" ", invalid_column) .. "^"
+end
+
+---Prints the line with an error marker line that points to some character.
+---@param line string The line to print
+---@param line_number number The line number to be printed
+---@param error_marker_column number 0-based column number to place the error marker
+local function print_line_with_error_marker(line, line_number, error_marker_column)
+    local line_number_width = 3
+
+    print(string.format("%" .. line_number_width .. "d: %s", line_number, line))
+    print(
+        string.format(
+            "%" .. line_number_width .. "s  %s\n",
+            "",
+            get_error_marker_line(error_marker_column)
+        )
+    )
+end
+
+describe("TSX highlighting", function()
+    it("should highlight", function()
+        -- TODO: enable based on file name
+        require("nvim-treesitter.configs").get_module("rainbow").extended_mode = true
+        vim.cmd.edit("test.tsx")
+        assert.equals("typescriptreact", vim.bo.filetype)
+
+        -- TODO: read source code from files
+        -- https://github.com/nvim-treesitter/nvim-treesitter/blob/a9a6493b1eeba458757903352e0d3dc4b54fd4f2/tests/query/highlights_spec.lua#L100
+        local source_code = [[
+    const abc = {};
+//hl            11
+    function MyComponent() {
+//hl                    11 1
+      return <div>Hello world</div>;
+//hl         22222           222221
+    }
+//hl1
+        ]]
+        local source_code_lines = vim.fn.split(source_code, "\n")
+
+        vim.api.nvim_buf_set_lines(0, 0, -1, true, source_code_lines)
+
+        local rainbow_ns_id = vim.api.nvim_get_namespaces().rainbow_ns
+        assert.not_equal(nil, rainbow_ns_id)
+
+        local parser = require("nvim-treesitter.parsers").get_parser(0)
+        assert.truthy(parser)
+        parser:parse()
+
+        for _, expected_highlight in ipairs(get_expected_highlights(source_code_lines)) do
+            local highlight_position = { expected_highlight.line, expected_highlight.column }
+
+            -- NOTE: does not return extmarks over a region when asking for a character inside of that region
+            -- TODO: refactor to get all buffer extmarks and then filter through it (`is_inside_extmark`)
+            local extmarks = vim.api.nvim_buf_get_extmarks(
+                0,
+                rainbow_ns_id,
+                highlight_position,
+                highlight_position,
+                { details = true }
+            )
+
+            -- TODO: verify that there are no extraneous highlights
+
+            if vim.tbl_isempty(extmarks) then
+                print(
+                    string.format(
+                        'No highlight groups detected. Expected "%s".',
+                        get_rainbow_highlight_group_name(expected_highlight.rainbow_level)
+                    )
+                )
+                print_line_with_error_marker(
+                    source_code_lines[expected_highlight.line + 1],
+                    expected_highlight.line + 1,
+                    expected_highlight.column
+                )
+            end
+
+            -- NOTE: nvim-ts-rainbow sometimes sets duplicated extmarks to highlight.
+            -- The extmarks should be the same.
+            for _, extmark in ipairs(extmarks) do
+                local details = extmark[4]
+                local expected_highlight_group =
+                    get_rainbow_highlight_group_name(expected_highlight.rainbow_level)
+                if expected_highlight_group ~= details.hl_group then
+                    print(
+                        string.format(
+                            'Invalid rainbow highlight group. Expected "%s", found "%s"',
+                            expected_highlight_group,
+                            details.hl_group
+                        )
+                    )
+                    print_line_with_error_marker(
+                        source_code_lines[expected_highlight.line + 1],
+                        expected_highlight.line + 1,
+                        expected_highlight.column
+                    )
+                end
+            end
+        end
+    end)
+end)

--- a/test/highlight/tsx_spec.lua
+++ b/test/highlight/tsx_spec.lua
@@ -63,12 +63,95 @@ local function print_line_with_error_marker(line, line_number, error_marker_colu
     )
 end
 
+---@class HighlightedSymbol
+---@field line number 0-based
+---@field column number 0-based
+---@field hl_group string
+
+---@param extmarks table[] Extmark returned from nvim_buf_get_extmarks
+---@return HighlightedSymbol[]
+local function get_highlighted_symbols_from_extmarks(extmarks)
+    ---@type HighlightedSymbol[]
+    local highlighted_symbols = {}
+
+    for _, extmark in ipairs(extmarks) do
+        -- TODO: support multi-line extmarks
+        local line = extmark[2]
+        local start_col = extmark[3]
+        local details = extmark[4]
+        ---Extmark is end_col-exclusive
+        local end_col = details.end_col
+
+        for col = start_col, end_col - 1 do
+            table.insert(highlighted_symbols, {
+                line = line,
+                column = col,
+                hl_group = details.hl_group,
+            })
+        end
+    end
+
+    return highlighted_symbols
+end
+
+---Prunes duplicate highlighted symbols ensuring that each symbol is highlighted
+---with a single highlight group.
+---nvim-ts-rainbow sometimes sets duplicated extmarks to highlight symbols.
+---Not pruning duplicates would mean errors would be reported multiple times
+--(once for each duplicate extmark).
+---@param highlighted_symbols HighlightedSymbol[] The table of highlighted symbols. it will be modified in place.
+---@param source_code_lines string[] Source code lines used for error reporting
+local function remove_duplicate_highlighted_symbols(highlighted_symbols, source_code_lines)
+    local multiple_highlights_for_symbols = false
+
+    -- NOTE: manual index tracking because one loop iteration can remove
+    -- multiple elements. Using iterators could iterate over removed indices
+    local index = 1
+    while index <= #highlighted_symbols do
+        local symbol = highlighted_symbols[index]
+
+        -- The body of the loop tries to prune duplicates in the range of
+        -- index+1..#highlighted_symbols
+
+        -- NOTE: loop from the end to allow removing elements in the loop while
+        -- preserving indices that will be looped over in the future
+        for other_symbol_index = #highlighted_symbols, index + 1, -1 do
+            local other_symbol = highlighted_symbols[other_symbol_index]
+            if symbol.line == other_symbol.line and symbol.column == other_symbol.column then
+                if symbol.hl_group == other_symbol.hl_group then
+                    table.remove(highlighted_symbols, other_symbol_index)
+                else
+                    print("Symbol has multiple different highlight groups assigned to it.")
+                    print(
+                        string.format(
+                            "Found highlight groups: %s %s",
+                            symbol.hl_group,
+                            other_symbol.hl_group
+                        )
+                    )
+
+                    print_line_with_error_marker(
+                        source_code_lines[symbol.line + 1],
+                        symbol.line + 1,
+                        symbol.column
+                    )
+                    multiple_highlights_for_symbols = true
+                end
+            end
+        end
+
+        index = index + 1
+    end
+
+    assert(not multiple_highlights_for_symbols, "There are multiple highlights for some symbols")
+end
+
 describe("TSX highlighting", function()
     it("should highlight", function()
         -- TODO: enable based on file name
         require("nvim-treesitter.configs").get_module("rainbow").extended_mode = true
         vim.cmd.edit("test.tsx")
-        assert.equals("typescriptreact", vim.bo.filetype)
+        assert.equals("typescriptreact", vim.bo.filetype, "Invalid filetype")
 
         -- TODO: read source code from files
         -- https://github.com/nvim-treesitter/nvim-treesitter/blob/a9a6493b1eeba458757903352e0d3dc4b54fd4f2/tests/query/highlights_spec.lua#L100
@@ -78,7 +161,7 @@ describe("TSX highlighting", function()
     function MyComponent() {
 //hl                    11 1
       return <div>Hello world</div>;
-//hl         22222           222221
+//hl         22222           222222
     }
 //hl1
         ]]
@@ -87,28 +170,63 @@ describe("TSX highlighting", function()
         vim.api.nvim_buf_set_lines(0, 0, -1, true, source_code_lines)
 
         local rainbow_ns_id = vim.api.nvim_get_namespaces().rainbow_ns
-        assert.not_equal(nil, rainbow_ns_id)
+        assert.not_equal(nil, rainbow_ns_id, "rainbow namespace not found")
 
         local parser = require("nvim-treesitter.parsers").get_parser(0)
-        assert.truthy(parser)
+        assert.truthy(parser, "Parser not found")
         parser:parse()
 
+        -- NOTE: nvim_buf_get_extmarks does not return extmarks that contain
+        -- some range. It only returns extmarks within the given range.
+        -- We cannot use it to look for extmarks for a given symbol, because sometimes
+        -- the extmarks are for a range (e.g. when highlighting a JSX tag, the
+        -- whole range "div" is a single extmark and asking for an extmark for
+        -- the position of "i" returns nothing).
+        -- Thus, we must filter through all extmarks set on the buffer and
+        -- check each symbol.
+        local extmarks = vim.api.nvim_buf_get_extmarks(0, rainbow_ns_id, 0, -1, { details = true })
+        local highlighted_symbols = get_highlighted_symbols_from_extmarks(extmarks)
+
+        remove_duplicate_highlighted_symbols(highlighted_symbols, source_code_lines)
+
         for _, expected_highlight in ipairs(get_expected_highlights(source_code_lines)) do
-            local highlight_position = { expected_highlight.line, expected_highlight.column }
+            local symbol_highlighted = false
 
-            -- NOTE: does not return extmarks over a region when asking for a character inside of that region
-            -- TODO: refactor to get all buffer extmarks and then filter through it (`is_inside_extmark`)
-            local extmarks = vim.api.nvim_buf_get_extmarks(
-                0,
-                rainbow_ns_id,
-                highlight_position,
-                highlight_position,
-                { details = true }
-            )
+            -- NOTE: loop from the end to allow removing elements inside of the loop
+            -- without changing the indices that will be looped over
+            for i = #highlighted_symbols, 1, -1 do
+                local highlighted_symbol = highlighted_symbols[i]
+                if
+                    highlighted_symbol.line == expected_highlight.line
+                    and highlighted_symbol.column == expected_highlight.column
+                then
+                    symbol_highlighted = true
 
-            -- TODO: verify that there are no extraneous highlights
+                    local expected_highlight_group =
+                        get_rainbow_highlight_group_name(expected_highlight.rainbow_level)
+                    if expected_highlight_group ~= highlighted_symbol.hl_group then
+                        print(
+                            string.format(
+                                'Invalid rainbow highlight group. Expected "%s", found "%s"',
+                                expected_highlight_group,
+                                highlighted_symbol.hl_group
+                            )
+                        )
+                        print_line_with_error_marker(
+                            source_code_lines[expected_highlight.line + 1],
+                            expected_highlight.line + 1,
+                            expected_highlight.column
+                        )
+                    end
 
-            if vim.tbl_isempty(extmarks) then
+                    -- NOTE: remove the matched highlighted symbol to later
+                    -- check that all highlighted symbols matched some expected
+                    -- highlight
+                    table.remove(highlighted_symbols, i)
+                end
+            end
+
+            if not symbol_highlighted then
                 print(
                     string.format(
                         'No highlight groups detected. Expected "%s".',
@@ -121,28 +239,21 @@ describe("TSX highlighting", function()
                     expected_highlight.column
                 )
             end
-
-            -- NOTE: nvim-ts-rainbow sometimes sets duplicated extmarks to highlight.
-            -- The extmarks should be the same.
-            for _, extmark in ipairs(extmarks) do
-                local details = extmark[4]
-                local expected_highlight_group =
-                    get_rainbow_highlight_group_name(expected_highlight.rainbow_level)
-                if expected_highlight_group ~= details.hl_group then
-                    print(
-                        string.format(
-                            'Invalid rainbow highlight group. Expected "%s", found "%s"',
-                            expected_highlight_group,
-                            details.hl_group
-                        )
-                    )
-                    print_line_with_error_marker(
-                        source_code_lines[expected_highlight.line + 1],
-                        expected_highlight.line + 1,
-                        expected_highlight.column
-                    )
-                end
-            end
         end
+
+        for _, symbol in ipairs(highlighted_symbols) do
+            print(
+                string.format(
+                    'Symbol was extraneously highlighted with highlight group "%s"',
+                    symbol.hl_group
+                )
+            )
+            print_line_with_error_marker(
+                source_code_lines[symbol.line + 1],
+                symbol.line + 1,
+                symbol.column
+            )
+        end
+        assert(#highlighted_symbols == 0, "Extraneous highlights")
     end)
 end)


### PR DESCRIPTION
I gave myself the challenge to write tests to check that this plugin highlights code correctly. I believe I managed to produce a file-based testing solution that makes it easy to test highlighting in multiple languages by creating additional source files.

The expected highlights are defined within the test source file using a DSL:

  * Each line that has at least 1 highlighted character needs a line below that specifies the rainbow level of that highlight.
  * The line with rainbow levels needs to have `hl` and then numbers or spaces. This line will most likely be a comment line to avoid treesitter parser errors.
  * The numbers must appear right below the character that should be highlighted (in the same column).

See the example in the changed files in this PR to visually understand what the format is. The tests only verify if the correct highlight group is applied to the source code. They do not check the actual color that gets applied. IMO just checking the rainbow level was enough.

I found it to be pretty easy to write tests this way.

## Extended mode vs regular mode

Whether a test runs in extended or regular mode is determined by the file name. If it includes `extended`, the test runs in extened mode. Otherwise, it runs in regular mode.

This allows easily testing both modes.

Thanks to these tests, I found a couple of bugs in the TSX highlighting that I fixed in this PR.

## Running tests

The tests are [plenary tests](https://github.com/nvim-lua/plenary.nvim#plenarytest_harness). I didn't add any CI step or minimal vim config to run them. I ran them manually by executing the `<Plug>PlenaryTestFile` mapping inside the spec buffer.

Both tests pass at the moment:

![image](https://user-images.githubusercontent.com/889383/183302073-a4e9e76c-8a6c-40d2-a362-63c97b07940f.png)

## Error reporting in the tests

I added some custom error reporting when there are:

* extraneous highlights

    ![image](https://user-images.githubusercontent.com/889383/183302145-3ca7306b-b8c6-400f-81bf-56c957a058b0.png)

* missing highlights
    
    ![image](https://user-images.githubusercontent.com/889383/183302189-ddcf2d38-2c89-401b-a139-24ab815645f2.png)

* wrong rainbow level highlights
    
    ![image](https://user-images.githubusercontent.com/889383/183302236-ebce68fc-a204-470e-88a9-6aa054372c1d.png)


The errors in the screenshots are simulated on purpose to show the error reporting.

## Real-life screenshots

Screenshots from the test TSX files to prove that I didn't break anything

Extended mode:

![image](https://user-images.githubusercontent.com/889383/183302354-07afbf61-9433-47fb-81d5-87ee3c3aee5a.png)


Regular mode:

![image](https://user-images.githubusercontent.com/889383/183302362-f6573402-6b22-497d-b388-137ae2c922e2.png)

The test results match the UI results.