### PR TITLE
Add highlighting `if` conditions in extended lua mode

### DIFF
--- a/lua/rainbow/internal.lua
+++ b/lua/rainbow/internal.lua
@@ -21,7 +21,7 @@ local api = vim.api
 
 local add_predicate = vim.treesitter.query.add_predicate
 local nsid = vim.api.nvim_create_namespace("rainbow_ns")
-local extended_languages = { "latex", "html", "verilog", "jsx", "elixir" }
+local extended_languages = { "latex", "html", "verilog", "jsx", "elixir", "lua" }
 local colors = configs.get_module("rainbow").colors
 local termcolors = configs.get_module("rainbow").termcolors
 

--- a/lua/rainbow/levels.lua
+++ b/lua/rainbow/levels.lua
@@ -166,6 +166,7 @@ return {
     lua = {
         arguments = true,
         bracket_index_expression = true,
+        if_statement = true,
         parameters = true,
         parenthesized_expression = true,
         table_constructor = true,

--- a/queries/lua/parens.scm
+++ b/queries/lua/parens.scm
@@ -1,1 +1,16 @@
 ; inherits: square,round,curly
+
+(if_statement
+    ["if" "then" "end"] @if
+    (#lua-extended-rainbow-mode? @if)
+)
+
+(elseif_statement
+    ["elseif" "then"] @elseif
+    (#lua-extended-rainbow-mode? @elseif)
+)
+
+(else_statement
+    ["else" "end"] @else
+    (#lua-extended-rainbow-mode? @else)
+)

--- a/test/highlight/lua/extended.lua
+++ b/test/highlight/lua/extended.lua
@@ -1,0 +1,41 @@
+local M = {}
+-- hl     11
+
+      if 1 == 2 then
+-- hl 11        1111
+        print("Something is wrong")
+        --hl 2                    2
+    end
+--hl111
+
+function M.setup(opts)
+    -- hl       1    1
+    opts = vim.tbl_extend("force", {
+        -- hl            1         2
+        debug_level = "error",
+    }, opts)
+--hl2      1
+
+    if opts.debug_level == "error" then
+--hl11                             1111
+        if opts.another_option then
+    --hl22                     2222
+            print("abc")
+            --hl 3     3
+        end
+    --hl222
+        print("Error debug level")
+        --hl 2                   2
+    elseif opts.debug_level == "info" then
+--hl111111                            1111
+        print("Info debug level")
+        --hl 2                  2
+    else
+--hl1111
+        print("Another debug level", opts.debug_level)
+        --hl 2                                       2
+    end
+--hl111
+end
+
+return M

--- a/test/highlight/lua/regular.lua
+++ b/test/highlight/lua/regular.lua
@@ -1,0 +1,33 @@
+local M = {}
+-- hl     11
+
+  if 1 == 2 then
+    print("Something is wrong")
+    --hl 2                    2
+end
+
+function M.setup(opts)
+    -- hl       1    1
+    opts = vim.tbl_extend("force", {
+        -- hl            1         2
+        debug_level = "error",
+    }, opts)
+--hl2      1
+
+    if opts.debug_level == "error" then
+        if opts.another_option then
+            print("abc")
+            --hl 3     3
+        end
+        print("Error debug level")
+        --hl 2                   2
+    elseif opts.debug_level == "info" then
+        print("Info debug level")
+        --hl 2                  2
+    else
+        print("Another debug level", opts.debug_level)
+        --hl 2                                       2
+    end
+end
+
+return M


### PR DESCRIPTION
Highlights "if", "else", "elseif", "then", "end" in `if` conditions.

![image](https://user-images.githubusercontent.com/889383/183649230-90c52ea7-2aed-47f5-bcbc-1c8166363ef0.png)


I'm doing this as an experiment. I'm not sure if it's actually useful.

If we add highlighting `if` conditions, then it may be useful to also highlight `function`s and `for` loops (or at least add them to `levels.lua`). This way we get highlighting similar to languages with curly braces for scopes, but highlight Lua keywords instead of curly braces.

Let me know what you think.

The tests are passing

![image](https://user-images.githubusercontent.com/889383/183649664-05a734ad-a203-4661-95e6-32294d95d017.png)

