### PR TITLE
fix: plugin not work when colors are more than termcolors

### DIFF
--- a/lua/rainbow/internal.lua
+++ b/lua/rainbow/internal.lua
@@ -156,14 +156,9 @@ local M = {}
 
 --- Define highlight groups. This had to be a function to allow an autocmd doing this at colorscheme change.
 function M.defhl()
+    local set_hl = vim.api.nvim_set_hl
     for i = 1, #colors do
-        local s = string.format(
-            "highlight default rainbowcol%d guifg=%s ctermfg=%s",
-            i,
-            colors[i],
-            termcolors[i]
-        )
-        vim.cmd(s)
+        set_hl(0, 'rainbowcol' .. i, { fg = colors[i], ctermfg = termcolors[i] })
     end
 end
 


### PR DESCRIPTION
If you defined `{colors = { "#cc241d", "#a89984" }, termcolors = {}}`, you can't reproduce the issue. Because there are seven colors and termcolors in default config.

If you defined colors more than seven,

    colors = { "#cc241d", "#a89984", "#b16286", "#d79921", "#689d6a", "#d65d0e", "#458588", "#005f87" },
    termcolors = {},

Or colors' length more than termcolors',

    colors = { "#cc241d", "#a89984"},
    termcolors = { 3 },

then the issue can be reproduced.

close #120