### PR TITLE
make it work on lines with comments

### DIFF
--- a/lua/rainbow/internal.lua
+++ b/lua/rainbow/internal.lua
@@ -69,9 +69,6 @@ local function update_range(bufnr, changes, tree, lang)
     end
 
     for _, change in ipairs(changes) do
-        --- clear highlights or code commented out later has highlights too
-        vim.api.nvim_buf_clear_namespace(bufnr, nsid, change[1], change[3] + 1)
-
         local root_node = tree:root()
         local query = queries.get_query(lang, "parens")
         local levels = require("rainbow.levels")[lang]


### PR DESCRIPTION
This fixes #145. The comment in the code says without clearing the namespace, commented code would have highlights too, but this isn't the case for me, when I comment out code that had Rainbow highlighting in it, the rainbow colors are correctly removed and the comment is just one color.